### PR TITLE
Fixing destroyed console issue

### DIFF
--- a/assets/components/gitpackagemanagement/js/mgr/widgets/packages.grid.js
+++ b/assets/components/gitpackagemanagement/js/mgr/widgets/packages.grid.js
@@ -258,7 +258,7 @@ Ext.extend(GitPackageManagement.grid.Packages,MODx.grid.Grid,{
                     ,'beforeSubmit': {fn:function() {
                         var topic = '/gitpackageinstall/';
                         var register = 'mgr';
-                        if(this.console == null){
+                        if(this.console === null || this.console.isDestroyed){
                             this.console = MODx.load({
                                 xtype: 'modx-console'
                                 ,register: register
@@ -286,7 +286,7 @@ Ext.extend(GitPackageManagement.grid.Packages,MODx.grid.Grid,{
                     ,'beforeSubmit': {fn:function() {
                         var topic = '/gitpackageuninstall/';
                         var register = 'mgr';
-                        if(this.console == null){
+                        if(this.console == null || this.console.isDestroyed){
                             this.console = MODx.load({
                                 xtype: 'modx-console'
                                 ,register: register


### PR DESCRIPTION
In my installation (Revo 2.3.2) this.console could not be shown because it gets an isDestroyed property.

It is quite easy to reproduce that error: Add a new package with a not existing folder two times. The second time a 'Uncaught TypeError: Cannot read property 'style' of undefined' occurs.

Maybe there is a better way to fix that issue.