### PR TITLE
Fixing #22 Menus without actions in Revo 2.3

### DIFF
--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -360,6 +360,9 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
                 ),'',true,true);
 
                 $menuObject->addOne($actionObject);
+            } elseif (!is_int($menu->getAction())) {
+                $menuObject->set('action', $menu->getAction());
+                $menuObject->set('namespace', $this->config->getLowCaseName());
             }
 
             $vehicle = $this->builder->createVehicle($menuObject, 'menu');


### PR DESCRIPTION
Namespaced menu entries were already defined in create/update class but not in buildpackage class.

Now I understand why the menu has worked fine locally :)