### PR TITLE
Allow array 'options' in config.json

### DIFF
--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigelement.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigelement.class.php
@@ -144,7 +144,7 @@ abstract class GitPackageConfigElement{
             }
 
             if (isset($property['options'])) {
-                $prop['options'] = $property['options'];
+                $prop['options'] = is_array($property['options']) ? $this->modx->toJSON($property['options']) : $property['options'];
             } else {
                 $prop['options'] = '';
             }


### PR DESCRIPTION
At the moment the options have to be written as JSON encoded string with escaped double quotes: 

```
"options": "[{\"text\":\"prop_xxx.yyy\",\"value\":\"yyy\"},{\"text\":\"prop_xxx.zzz\",\"value\":\"zzz\"}]",
```

This notation is possible after:
```
"options": [
    {
        "text": "prop_xxx.yyy",
        "value": "yyy"
    },
    {
        "text": "prop_xxx.zzz",
        "value": "zzz"
    }
],
```

Useful i.e. for `"type": "list"` in snippet properties.