### PR TITLE
Allow array 'inputProperties'/'outputProperties' in config.json

### DIFF
--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigelementtv.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigelementtv.class.php
@@ -38,11 +38,11 @@ class GitPackageConfigElementTV extends GitPackageConfigElement{
         }
 
         if(isset($config['inputProperties'])){
-            $this->inputProperties = $config['inputProperties'];
+            $this->inputProperties = is_array($config['inputProperties']) ? $this->modx->toJSON($config['inputProperties']) : $config['inputProperties'];
         }
 
         if(isset($config['outputProperties'])){
-            $this->outputProperties = $config['outputProperties'];
+            $this->inputProperties = is_array($config['outputProperties']) ? $this->modx->toJSON($config['outputProperties']) : $config['outputProperties'];
         }
 
         if(isset($config['sortOrder'])){

--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigelementtv.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigelementtv.class.php
@@ -42,7 +42,7 @@ class GitPackageConfigElementTV extends GitPackageConfigElement{
         }
 
         if(isset($config['outputProperties'])){
-            $this->inputProperties = is_array($config['outputProperties']) ? $this->modx->toJSON($config['outputProperties']) : $config['outputProperties'];
+            $this->outputProperties = is_array($config['outputProperties']) ? $this->modx->toJSON($config['outputProperties']) : $config['outputProperties'];
         }
 
         if(isset($config['sortOrder'])){


### PR DESCRIPTION
Should fix #45 (see PR #50 how the inputProperties'/'outputProperties have to be written at the moment)