### PR TITLE
Fix issue with non-valid JSON config file

### DIFF
--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/update.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/update.class.php
@@ -41,6 +41,10 @@ class GitPackageManagementUpdatePackageProcessor extends modObjectUpdateProcesso
         $config = file_get_contents($configFile);
 
         $config = $this->modx->fromJSON($config);
+        
+        if (is_null($config)) {
+            return 'JSON config file is not valid.';
+        }
 
         $this->newConfig = new GitPackageConfig($this->modx, $packagePath);
         $this->newConfig->parseConfig($config);


### PR DESCRIPTION
Was getting wrong error messages for non-valid config.json file