### PR TITLE
Added ability to execute the manager controller without creating a modAction record

### DIFF
--- a/core/components/gitpackagemanagement/controllers/home.class.php
+++ b/core/components/gitpackagemanagement/controllers/home.class.php
@@ -5,6 +5,9 @@
  * @package gitpackagemanagement
  * @subpackage controllers
  */
+if (!class_exists('GitPackageManagementBaseManagerController')) {
+    require_once __DIR__ .'/../index.class.php';
+}
 class GitPackageManagementHomeManagerController extends GitPackageManagementBaseManagerController {
     public function process(array $scriptProperties = array()) {
 


### PR DESCRIPTION
This should allow accessing the manager controller using `?a=home&namespace=gitpackagemanagement`