### PR TITLE
Transport package dir

### DIFF
--- a/core/components/gitpackagemanagement/lexicon/en/default.inc.php
+++ b/core/components/gitpackagemanagement/lexicon/en/default.inc.php
@@ -33,6 +33,8 @@ $_lang['gitpackagemanagement.preserve_package'] = 'Preserve package';
 $_lang['gitpackagemanagement.build_package'] = 'Build package';
 
 //Options
+$_lang['setting_gitpackagemanagement.build_path'] = 'Build path';
+$_lang['setting_gitpackagemanagement.build_path_desc'] = 'Folder, relatives to the package, to store build transport packages. Defaults to "/_packages/"';
 $_lang['setting_gitpackagemanagement.packages_dir'] = 'Packages directory';
 $_lang['setting_gitpackagemanagement.packages_dir_desc'] = 'Path to the directory where you store packages.';
 $_lang['setting_gitpackagemanagement.packages_base_url'] = 'Packages base URL';

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -75,7 +75,10 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
             $version[1] = 'pl';
         }
 
-        $this->builder->getTPBuilder()->directory = $this->config->getPackagePath() . '/_packages/';
+        $this->builder->getTPBuilder()->directory = $this->config->getPackagePath() . $this->modx->getOption('gitpackagemanagement.build_path', null, '/_packages/');
+        if (!is_dir($this->builder->getTPBuilder()->directory)) {
+            mkdir($this->builder->getTPBuilder()->directory);
+        }
         $this->builder->getTPBuilder()->createPackage($this->config->getLowCaseName(), $version[0], $version[1]);
 
         $this->builder->registerNamespace($this->config->getLowCaseName(), false, true, '{core_path}components/' . $this->config->getLowCaseName() . '/','{assets_path}components/' . $this->config->getLowCaseName() . '/');


### PR DESCRIPTION
Added ability to define the path (relative to the component folder) where transport packages will be stored, using `gitpackagemanagement.build_path` system setting