### PR TITLE
Don't assign a template if the TV does not contain one

### DIFF
--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/create.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/create.class.php
@@ -626,12 +626,15 @@ class GitPackageManagementCreateProcessor extends modObjectCreateProcessor {
                 $tvObject->setProperties($tv->getProperties());
                 $tvObject->save();
 
-                $templates = $this->modx->getCollection('modTemplate', array('templatename:IN' => $tv->getTemplates()));
-                foreach($templates as $template){
-                    $templateTVObject = $this->modx->newObject('modTemplateVarTemplate');
-                    $templateTVObject->set('tmplvarid', $tvObject->id);
-                    $templateTVObject->set('templateid', $template->id);
-                    $templateTVObject->save();
+                $templates = $tv->getTemplates();
+                if (!empty($templates)) {
+                    $templates = $this->modx->getCollection('modTemplate', array('templatename:IN' => $tv->getTemplates()));
+                    foreach ($templates as $template) {
+                        $templateTVObject = $this->modx->newObject('modTemplateVarTemplate');
+                        $templateTVObject->set('tmplvarid', $tvObject->id);
+                        $templateTVObject->set('templateid', $template->id);
+                        $templateTVObject->save();
+                    }
                 }
 
                 $this->modx->log(modX::LOG_LEVEL_INFO, 'TV ' . $tv->getName() . ' created.');

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/create.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/create.class.php
@@ -417,7 +417,7 @@ class GitPackageManagementCreateProcessor extends modObjectCreateProcessor {
                 $pluginObject->set('description', $plugin->getDescription());
                 $pluginObject->set('property_preprocess', $plugin->getPropertyPreProcess());
                 if ($this->modx->gitpackagemanagement->getOption('enable_debug')) {
-                    $pluginObject->set('plugincode', 'include("' . $this->modx->getOption($this->config->getLowCaseName() . '.core_path') . $plugin->getFilePath() . '");');
+                    $pluginObject->set('plugincode', 'include("' . $this->packageCorePath . $plugin->getFilePath() . '");');
                     $pluginObject->set('static', 0);
                     $pluginObject->set('static_file', '');
                 } else {
@@ -474,7 +474,7 @@ class GitPackageManagementCreateProcessor extends modObjectCreateProcessor {
                 $snippetObject->set('description', $snippet->getDescription());
                 $snippetObject->set('property_preprocess', $snippet->getPropertyPreProcess());
                 if ($this->modx->gitpackagemanagement->getOption('enable_debug')) {
-                    $snippetObject->set('snippet', 'return include("' . $this->modx->getOption($this->config->getLowCaseName() . '.core_path') . $snippet->getFilePath() . '");');
+                    $snippetObject->set('snippet', 'return include("' . $this->packageCorePath . $snippet->getFilePath() . '");');
                     $snippetObject->set('static', 0);
                     $snippetObject->set('static_file', '');
                 } else {

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/update.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/update.class.php
@@ -411,12 +411,15 @@ class GitPackageManagementUpdatePackageProcessor extends modObjectUpdateProcesso
             $tvObject->setProperties($tvObject->getProperties());
             $tvObject->save();
 
-            $templates = $this->modx->getCollection('modTemplate', array('templatename:IN' => $tv->getTemplates()));
-            foreach($templates as $template){
-                $templateTVObject = $this->modx->newObject('modTemplateVarTemplate');
-                $templateTVObject->set('tmplvarid', $tvObject->id);
-                $templateTVObject->set('templateid', $template->id);
-                $templateTVObject->save();
+            $templates = $tv->getTemplates();
+            if (!empty($templates)) {
+                $templates = $this->modx->getCollection('modTemplate', array('templatename:IN' => $tv->getTemplates()));
+                foreach ($templates as $template) {
+                    $templateTVObject = $this->modx->newObject('modTemplateVarTemplate');
+                    $templateTVObject->set('tmplvarid', $tvObject->id);
+                    $templateTVObject->set('templateid', $template->id);
+                    $templateTVObject->save();
+                }
             }
 
             if(isset($notUsedElements[$name])){


### PR DESCRIPTION
Fixing the following errors if a TV created by GPM does not has a template assigned: 
```
Encountered empty IN condition with key templatename
```
and
```
Error 42000 executing statement: 
Array
(
    [0] => 42000
    [1] => 1064
    [2] => You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1
)
```