### PR TITLE
Change type of Config field to mediumtext

### DIFF
--- a/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
+++ b/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
@@ -6,7 +6,7 @@
         <field key="version" dbtype="varchar" precision="32" phptype="string" null="false" default="" />
         <field key="author" dbtype="varchar" precision="32" phptype="string" null="false" default="" />
         <field key="dir_name" dbtype="varchar" precision="100" phptype="string" null="false" />
-        <field key="config" dbtype="text" phptype="string" null="false" default="" />
+        <field key="config" dbtype="mediumtext" phptype="string" null="false" default="" />
         <field key="key" dbtype="varchar" precision="32" phptype="string" null="false" default="" />
     </object>
 </model>


### PR DESCRIPTION
If set to text, the maximum size of the content is just 65535 chars. When you have a package with a big config file (containing a lot of resources for example), the content inside the database field gets clipped at some point, resulting in errors such as "You can not update your package because you changed package's name. Please remove package and install it again." or just empty alert messages.

Setting it to mediumtext allows for around 16Mb of content, which immediately solved the issues I was having.