### PR TITLE
Prepend/Append Vehicles

### DIFF
--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/builder/gitpackagebuilder.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/builder/gitpackagebuilder.class.php
@@ -120,7 +120,7 @@ class GitPackageBuilder {
     }
 
     private function getAttributes($type){
-        return $this->attributes[$type];
+        return (is_string($type)) ? $this->attributes[$type] : $type;
     }
 
     public function registerNamespace($ns = 'core', $autoIncludes = true, $packageNamespace = true, $path = '', $assetsPath = ''){

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -83,6 +83,8 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         $this->builder->registerNamespace($this->config->getLowCaseName(), false, true, '{core_path}components/' . $this->config->getLowCaseName() . '/','{assets_path}components/' . $this->config->getLowCaseName() . '/');
 
+        $this->prependVehicles();
+
         $vehicle = $this->addCategory();
 
         $resolver = $buildOptions->getResolver();
@@ -161,6 +163,8 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         $this->builder->putVehicle($vehicle);
         $this->addMenus();
+
+        $this->appendVehicles();
 
         $packageAttributes = array();
 
@@ -446,6 +450,10 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         return $plugins;
     }
+
+    protected function prependVehicles() {}
+
+    protected function appendVehicles() {}
 
     private function addMenus() {
         /** @var GitPackageConfigMenu[] $menus */


### PR DESCRIPTION
Allow prepending/appending custom vehicles to the package (i.e. for adding file/script vehicle combination that decodes the payload of the category vehicle).

Also changed the GitPackageBuilder getAttributes a bit to allow a custom attributes array.