### PR TITLE
Ensure snippets and plugins etc are trimmed correctly

### DIFF
--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -312,7 +312,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
                 $snippetObject->set('name', $configSnippet->getName());
                 $snippetObject->set('description', $configSnippet->getDescription());
                 $snippetObject->set('property_preprocess', $configSnippet->getPropertyPreProcess());
-                $snippetObject->set('snippet', $this->builder->getFileContent($this->corePath . $configSnippet->getFilePath()));
+                $snippetObject->set('content', $this->builder->getFileContent($this->corePath . $configSnippet->getFilePath()));
 
                 $snippetObject->setProperties($configSnippet->getProperties());
                 $snippets[] = $snippetObject;
@@ -335,7 +335,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
                 $chunkObject->set('name', $configChunk->getName());
                 $chunkObject->set('description', $configChunk->getDescription());
                 $chunkObject->set('property_preprocess', $configChunk->getPropertyPreProcess());
-                $chunkObject->set('snippet', $this->builder->getFileContent($this->corePath . $configChunk->getFilePath()));
+                $chunkObject->set('content', $this->builder->getFileContent($this->corePath . $configChunk->getFilePath()));
 
                 $chunkObject->setProperties($configChunk->getProperties());
                 $chunks[] = $chunkObject;
@@ -422,7 +422,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
                 $pluginObject->set('name', $configPlugin->getName());
                 $pluginObject->set('description', $configPlugin->getDescription());
                 $pluginObject->set('property_preprocess', $configPlugin->getPropertyPreProcess());
-                $pluginObject->set('plugincode', $this->builder->getFileContent($this->corePath . $configPlugin->getFilePath()));
+                $pluginObject->set('content', $this->builder->getFileContent($this->corePath . $configPlugin->getFilePath()));
 
                 $events = $configPlugin->getEvents();
                 if (count($events) > 0) {


### PR DESCRIPTION
Due to a recent commit in the MODX core (https://github.com/modxcms/revolution/commit/9bf6b342da75a2a35ef5927acee914723e284dd6), elements passed to the 'getFileContent' func during a build are not trimmed correctly.

For example, the start and end php tags are not trimmed from snippets resulting with:

`<?php <?php $snippetContent ?>`

in the cache files and a 500 error on any page with a snippet call.
