### PR TITLE
Fixing invalid file/folder permissions

### DIFF
--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/builder/gitpackagebuilder.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/builder/gitpackagebuilder.class.php
@@ -140,8 +140,8 @@ class GitPackageBuilder {
         if ($this->modx->gitpackagemanagement->getOption('remove_extracted_package')) {
             $this->modx->gitpackagemanagement->deleteDir($this->builder->directory . $this->builder->signature . '/');
         }
-        chmod($this->builder->directory, octdec($this->modx->getOption('new_folder_permissions')));
-        chmod($this->builder->directory . $this->builder->signature . '.transport.zip', octdec($this->modx->getOption('new_file_permissions')));
+        chmod($this->builder->directory, octdec($this->modx->getOption('new_folder_permissions', null, '0775')));
+        chmod($this->builder->directory . $this->builder->signature . '.transport.zip', octdec($this->modx->getOption('new_file_permissions', null, '0644')));
     }
 
 


### PR DESCRIPTION
Fixing #109 and add some default permissions for the case that none are defined in MODX system settings.