### PR TITLE
 Add an empty_folders build option

### DIFF
--- a/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
+++ b/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="gitpackagemanagement">
+<model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="gitpackagemanagement">
     <object class="GitPackage" table="git_packages" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="100" phptype="string" null="false" />
         <field key="description" dbtype="text" phptype="text" null="false" default="" />

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -51,6 +51,15 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         $this->loadSmarty();
 
+        $buildOptions = $this->config->getBuild()->getBuildOptions();
+        $emptyFolders = $this->modx->getOption('empty_folders', $buildOptions, array());
+        if (!empty($emptyFolders)) {
+            foreach ($emptyFolders as $emptyFolder => $emptyFiles) {
+                $emptyFolder = str_replace('{package_path}', $this->config->getPackagePath() . '/', $emptyFolder);
+                $this->emptyFolder($emptyFolder, $emptyFiles);
+            }
+        }
+
         return true;
     }
 
@@ -130,7 +139,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
             $prefix = $db->getPrefix();
 
             if (!is_array($extensionPackage)) $extensionPackage = array();
-            
+
             if (isset($prefix)) {
                 $extensionPackage['tablePrefix'] = $prefix;
             }
@@ -450,6 +459,29 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
         }
 
         return $plugins;
+    }
+
+    protected function emptyFolder($path, $filemask = '*')
+    {
+        $inverse = false;
+        if (strpos($filemask, '!') === 0) {
+            $filemask = substr($filemask, 1);
+            $inverse = true;
+        }
+        $files = glob($path . '/' . $filemask, GLOB_BRACE);
+        if ($inverse) {
+            $allFiles = glob($path . '/*');
+            $files = array_diff($allFiles, $files);
+        }
+        foreach ($files as $file) {
+            if (is_dir($file)) {
+                $this->emptyFolder($file, '*');
+                rmdir($file);
+            } else {
+                unlink($file);
+            }
+        }
+        return;
     }
 
     protected function prependVehicles() {}


### PR DESCRIPTION
In a few packages some temporary files are created during testing in some vendor folders (in my case mPDF). I have added an build option that empties those folders before packaging. The following config options could be used:

```
  "build": {
    "options": {
      "empty_folders": {
        "{package_path}core/components/xxx/vendor/mpdf/mpdf/tmp" : "*",
        "{package_path}core/components/xxx/vendor/mpdf/mpdf/ttfonts" : "!{DejaVu,Free}*",
        "{package_path}core/components/xxx/vendor/mpdf/mpdf/ttfontdata" : "*"
      }
    },
    ...
  }
```

It uses the glob braces option to select the files. There is an inverse option available with the `!` char, that selects all files except the selected ones