### PR TITLE
Add validator to the category vehicle

### DIFF
--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/builder/gitpackagevehicle.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/builder/gitpackagevehicle.class.php
@@ -15,6 +15,14 @@ class GitPackageVehicle {
         $this->vehicle = $this->builder->createVehicle($object, $attributes);
     }
 
+    public function addPhpValidator($filePath) {
+        $this->vehicle->validate('php', array(
+            'source' => $filePath,
+        ));
+
+        return $this;
+    }
+
     public function addAssetsResolver($assetsPath){
         return $this->addFileResolver($assetsPath, "return MODX_ASSETS_PATH . 'components/';");
     }

--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfig.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfig.class.php
@@ -60,6 +60,7 @@ class GitPackageConfig {
         $this->modx->loadClass('GitPackageConfigElementWidget', $this->gpm->getOption('modelPath') . 'gitpackagemanagement/gpc/', true, true);
         $this->modx->loadClass('GitPackageConfigResource', $this->gpm->getOption('modelPath') . 'gitpackagemanagement/gpc/', true, true);
         $this->modx->loadClass('GitPackageConfigBuild', $this->gpm->getOption('modelPath') . 'gitpackagemanagement/gpc/', true, true);
+        $this->modx->loadClass('GitPackageConfigBuildValidator', $this->gpm->getOption('modelPath') . 'gitpackagemanagement/gpc/', true, true);
         $this->modx->loadClass('GitPackageConfigBuildResolver', $this->gpm->getOption('modelPath') . 'gitpackagemanagement/gpc/', true, true);
         $this->modx->loadClass('GitPackageConfigCategory', $this->gpm->getOption('modelPath') . 'gitpackagemanagement/gpc/', true, true);
 
@@ -70,7 +71,7 @@ class GitPackageConfig {
 
     /**
      * Parse and validate given array into objects
-     * @param $config Array
+     * @param $config array
      * @return bool
      */
     public function parseConfig($config) {

--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigbuild.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigbuild.class.php
@@ -4,6 +4,8 @@ class GitPackageConfigBuild {
     private $modx;
     /** @var GitPackageConfig $config */
     private $config;
+    /** @var GitPackageConfigBuildValidator $validator */
+    private $validator;
     /** @var GitPackageConfigBuildResolver $resolver */
     private $resolver;
     private $readme = 'docs/readme.txt';
@@ -16,11 +18,16 @@ class GitPackageConfigBuild {
 
     public function __construct(modX &$modx, GitPackageConfig $config) {
         $this->modx =& $modx;
+        $this->validator = new GitPackageConfigBuildValidator($this->modx);
         $this->resolver = new GitPackageConfigBuildResolver($this->modx);
         $this->config = $config;
     }
 
     public function fromArray($config) {
+        if(isset($config['validator'])){
+            $this->validator->fromArray($config['validator']);
+        }
+
         if(isset($config['resolver'])){
             $this->resolver->fromArray($config['resolver']);
         }
@@ -74,6 +81,20 @@ class GitPackageConfigBuild {
      */
     public function setResolver($resolver) {
         $this->resolver = $resolver;
+    }
+
+    /**
+     * @return GitPackageConfigBuildValidator
+     */
+    public function getValidator() {
+        return $this->validator;
+    }
+
+    /**
+     * @param GitPackageConfigBuildValidator $validator
+     */
+    public function setValidator($validator) {
+        $this->validator = $validator;
     }
 
     /**

--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigbuildvalidator.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/gpc/gitpackageconfigbuildvalidator.class.php
@@ -1,0 +1,51 @@
+<?php
+
+class GitPackageConfigBuildValidator {
+    private $modx;
+    private $validatorsDir = 'validators';
+    private $validators = array();
+
+    public function __construct(modX &$modx) {
+        $this->modx =& $modx;
+    }
+
+    public function fromArray($config) {
+        if(isset($config['validatorsDir'])){
+            $this->validatorsDir = $config['validatorsDir'];
+        }
+
+        if(isset($config['validators'])){
+            $this->validators = $config['validators'];
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValidatorsDir() {
+        return $this->validatorsDir;
+    }
+
+    /**
+     * @param string $validatorsDir
+     */
+    public function setValidatorsDir($validatorsDir) {
+        $this->validatorsDir = $validatorsDir;
+    }
+
+    /**
+     * @return array
+     */
+    public function getValidators() {
+        return $this->validators;
+    }
+
+    /**
+     * @param array $validators
+     */
+    public function setValidators($validators) {
+        $this->validators = $validators;
+    }
+}

--- a/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
+++ b/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="gitpackagemanagement">
+<model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="gitpackagemanagement">
     <object class="GitPackage" table="git_packages" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="100" phptype="string" null="false" />
         <field key="description" dbtype="text" phptype="text" null="false" default="" />

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -29,14 +29,14 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
         if (!$this->object) return $this->failure();
 
         $this->packagePath = rtrim($this->modx->getOption('gitpackagemanagement.packages_dir', null, null), '/') . '/';
-        if($this->packagePath == null){
+        if ($this->packagePath == null) {
             return $this->modx->lexicon('gitpackagemanagement.package_err_ns_packages_dir');
         }
 
         $packagePath = $this->packagePath . $this->object->dir_name;
 
         $configFile = $packagePath . $this->modx->gitpackagemanagement->configPath;
-        if(!file_exists($configFile)){
+        if (!file_exists($configFile)) {
             return $this->modx->lexicon('gitpackagemanagement.package_err_url_config_nf');
         }
 
@@ -45,7 +45,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
         $config = $this->modx->fromJSON($config);
 
         $this->config = new GitPackageConfig($this->modx, $packagePath);
-        if($this->config->parseConfig($config) == false) {
+        if ($this->config->parseConfig($config) == false) {
             return $this->modx->lexicon('gitpackagemanagement.package_err_url_config_nf');
         }
 
@@ -81,11 +81,23 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
         }
         $this->builder->getTPBuilder()->createPackage($this->config->getLowCaseName(), $version[0], $version[1]);
 
-        $this->builder->registerNamespace($this->config->getLowCaseName(), false, true, '{core_path}components/' . $this->config->getLowCaseName() . '/','{assets_path}components/' . $this->config->getLowCaseName() . '/');
+        $this->builder->registerNamespace($this->config->getLowCaseName(), false, true, '{core_path}components/' . $this->config->getLowCaseName() . '/', '{assets_path}components/' . $this->config->getLowCaseName() . '/');
 
         $this->prependVehicles();
 
+        /** @var GitPackageVehicle $vehicle */
         $vehicle = $this->addCategory();
+
+        $validator = $buildOptions->getValidator();
+
+        $validatorsDir = $validator->getValidatorsDir();
+        $validatorsDir = trim($validatorsDir, '/');
+        $validatorsDir = $this->packagePath . '_build/' . $validatorsDir . '/';
+
+        $validators = $validator->getValidators();
+        foreach ($validators as $script) {
+            $vehicle->addPhpValidator($validatorsDir . ltrim($script, '/'));
+        }
 
         $resolver = $buildOptions->getResolver();
 
@@ -94,7 +106,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
         $resolversDir = $this->packagePath . '_build/' . $resolversDir . '/';
 
         $before = $resolver->getBefore();
-        foreach($before as $script) {
+        foreach ($before as $script) {
             $vehicle->addPHPResolver($resolversDir . ltrim($script, '/'));
         }
 
@@ -157,7 +169,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
         $this->addSystemSettings();
 
         $after = $resolver->getAfter();
-        foreach($after as $script) {
+        foreach ($after as $script) {
             $vehicle->addPHPResolver($resolversDir . ltrim($script, '/'));
         }
 
@@ -308,8 +320,8 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         /** @var GitPackageConfigElementSnippet[] $configSnippets */
         $configSnippets = $this->config->getElements('snippets');
-        if(count($configSnippets) > 0){
-            foreach($configSnippets as $configSnippet){
+        if (count($configSnippets) > 0) {
+            foreach ($configSnippets as $configSnippet) {
                 if ($configSnippet->getCategory() != $category) continue;
 
                 $snippetObject = $this->modx->newObject('modSnippet');
@@ -331,8 +343,8 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         /** @var GitPackageConfigElementChunk[] $configChunks */
         $configChunks = $this->config->getElements('chunks');
-        if(count($configChunks) > 0){
-            foreach($configChunks as $configChunk){
+        if (count($configChunks) > 0) {
+            foreach ($configChunks as $configChunk) {
                 if ($configChunk->getCategory() != $category) continue;
 
                 $chunkObject = $this->modx->newObject('modChunk');
@@ -354,8 +366,8 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         /** @var GitPackageConfigElementTemplate[] $configTemplates */
         $configTemplates = $this->config->getElements('templates');
-        if(count($configTemplates) > 0){
-            foreach($configTemplates as $configTemplate){
+        if (count($configTemplates) > 0) {
+            foreach ($configTemplates as $configTemplate) {
                 if ($configTemplate->getCategory() != $category) continue;
 
                 $templateObject = $this->modx->newObject('modTemplate');
@@ -378,8 +390,8 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         /** @var GitPackageConfigElementTV[] $configTVs */
         $configTVs = $this->config->getElements('tvs');
-        if(count($configTVs) > 0){
-            foreach($configTVs as $configTV){
+        if (count($configTVs) > 0) {
+            foreach ($configTVs as $configTV) {
                 if ($configTV->getCategory() != $category) continue;
 
                 $tvObject = $this->modx->newObject('modTemplateVar');
@@ -395,12 +407,12 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
                 $inputProperties = $configTV->getInputProperties();
                 if (!empty($inputProperties)) {
-                    $tvObject->set('input_properties',$inputProperties);
+                    $tvObject->set('input_properties', $inputProperties);
                 }
 
                 $outputProperties = $configTV->getOutputProperties();
                 if (!empty($outputProperties)) {
-                    $tvObject->set('output_properties',$outputProperties);
+                    $tvObject->set('output_properties', $outputProperties);
                 }
 
                 $tvObject->setProperties($configTV->getProperties());
@@ -417,9 +429,9 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
 
         /** @var GitPackageConfigElementPlugin[] $configPlugins */
         $configPlugins = $this->config->getElements('plugins');
-        if(count($configPlugins) > 0){
+        if (count($configPlugins) > 0) {
 
-            foreach($configPlugins as $configPlugin){
+            foreach ($configPlugins as $configPlugin) {
                 if ($configPlugin->getCategory() != $category) continue;
 
                 $pluginObject = $this->modx->newObject('modPlugin');
@@ -471,7 +483,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
                 'params' => $menu->getParams(),
                 'handler' => $menu->getHandler(),
                 'permissions' => $menu->getPermissions(),
-            ),'',true,true);
+            ), '', true, true);
 
             $configAction = $menu->getActionObject();
             if ($configAction !== null) {
@@ -484,7 +496,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
                     'haslayout' => $configAction->getHasLayout(),
                     'lang_topics' => $configAction->getLangTopics(),
                     'assets' => $configAction->getAssets(),
-                ),'',true,true);
+                ), '', true, true);
 
                 $menuObject->addOne($actionObject);
             } else {
@@ -542,7 +554,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
     }
 
     private function loadSmarty() {
-        $this->smarty = $this->modx->getService('smarty','smarty.modSmarty');
+        $this->smarty = $this->modx->getService('smarty', 'smarty.modSmarty');
         $this->smarty->setTemplatePath($this->modx->gitpackagemanagement->getOption('templatesPath') . '/gitpackagebuild/');
 
         $this->smarty->assign('lowercasename', $this->config->getLowCaseName());


### PR DESCRIPTION
These changes add validators to the category vehicle.

Validators could be set with the following setting in the config.json.

```
    "build": {
        "validator": {
            "validatorsPath": "validators",             
            "validators": [
                "myown.validator.php"
            ]
        }
    }
```

Validators are located by default in `_build/validators`. They stop the installation of a package if the code returns false. When #114 is merged and `abort_install_on_vehicle_fail` is set to true, the package is not marked as installed, if the installation of the package is stopped. Otherwise the package is marked as installed, but it is not installed.
