### PR TITLE
Abort install on vehicle fail

### DIFF
--- a/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
+++ b/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="gitpackagemanagement">
+<model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="gitpackagemanagement">
     <object class="GitPackage" table="git_packages" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="100" phptype="string" null="false" />
         <field key="description" dbtype="text" phptype="text" null="false" default="" />

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -255,7 +255,16 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
             $category->addMany($categories, 'Children');
         }
 
-        return $this->builder->createVehicle($category, 'category');
+        $category = $this->builder->createVehicle($category, 'category');
+
+        $buildOptions = $this->config->getBuild()->getBuildOptions();
+
+        if ($this->modx->getOption('abort_install_on_vehicle_fail', $buildOptions, false)) {
+            $categoryVehicle = $category->getVehicle();
+            $categoryVehicle->attributes[xPDOTransport::ABORT_INSTALL_ON_VEHICLE_FAIL] = true;
+        }
+
+        return $category;
     }
 
     private function getCategories($parent = null) {


### PR DESCRIPTION
This change adds an activation of the the xPDOTransport::ABORT_INSTALL_ON_VEHICLE_FAIL option for a package.

When the package should be installed and a validator or a resolver returns false, the package is not marked as installed.

The option could be set with the following setting in the config.json.

```
    "build": {
        "options": {
            "abort_install_on_vehicle_fail": true
        },
    }
```
