### PR TITLE
Schema fix

### DIFF
--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/mysql/gitpackage.map.inc.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/mysql/gitpackage.map.inc.php
@@ -29,7 +29,7 @@ $xpdo_meta_map['GitPackage']= array (
     'description' => 
     array (
       'dbtype' => 'text',
-      'phptype' => 'text',
+      'phptype' => 'string',
       'null' => false,
       'default' => '',
     ),

--- a/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
+++ b/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="MyISAM" phpdoc-package="gitpackagemanagement">
+<model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="gitpackagemanagement">
     <object class="GitPackage" table="git_packages" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="100" phptype="string" null="false" />
         <field key="description" dbtype="text" phptype="text" null="false" default="" />

--- a/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
+++ b/core/components/gitpackagemanagement/model/schema/gitpackagemanagement.mysql.schema.xml
@@ -2,7 +2,7 @@
 <model package="gitpackagemanagement" baseClass="xPDOObject" platform="mysql" defaultEngine="InnoDB" phpdoc-package="gitpackagemanagement">
     <object class="GitPackage" table="git_packages" extends="xPDOSimpleObject">
         <field key="name" dbtype="varchar" precision="100" phptype="string" null="false" />
-        <field key="description" dbtype="text" phptype="text" null="false" default="" />
+        <field key="description" dbtype="text" phptype="string" null="false" default="" />
         <field key="version" dbtype="varchar" precision="32" phptype="string" null="false" default="" />
         <field key="author" dbtype="varchar" precision="32" phptype="string" null="false" default="" />
         <field key="dir_name" dbtype="varchar" precision="100" phptype="string" null="false" />


### PR DESCRIPTION
At the moment the description will be set to '0' instead of a string value in MODX 2.7.1 running on PHP 7.2 with MySQL 5.7.23 (database type is MyISAM). 

According to Xdebug this could be caused by a wrong PDO type binding.