### PR TITLE
Fix Field 'name' doesn't have a default value

### DIFF
--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/create.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/create.class.php
@@ -151,7 +151,6 @@ class GitPackageManagementCreateProcessor extends modObjectCreateProcessor {
         }
 
         $this->object->set('config', $this->modx->toJSON($configContent));
-        $this->object->save();
         $this->modx->log(modX::LOG_LEVEL_INFO, 'Config file is valid.');
         return true;
 


### PR DESCRIPTION
The processor throws the following error during adding a new package:

```
Array ( [0] => HY000 [1] => 1364 [2] => Field 'name' doesn't have a default value )
```

This is because the package name is not set at that time. The whole object is saved later on, so it does not have to be saved at that time.