### PR TITLE
Add option for a file log

### DIFF
--- a/_build/gpm.yml
+++ b/_build/gpm.yml
@@ -17,6 +17,10 @@ systemSettings:
     area: system
     type: combo-boolean
     value: 0
+  - key: enable_file_log
+    area: system
+    type: combo-boolean
+    value: 0
 
 database:
   tables:

--- a/core/components/gpm/src/Logger/MODX.php
+++ b/core/components/gpm/src/Logger/MODX.php
@@ -41,6 +41,13 @@ final class MODX implements LoggerInterface
             $level = self::$levelMap[$level];
         }
 
-        $this->modx->log($level, $message);
+        $target = (!$this->getOption('enable_file_log')) ? '' : array(
+            'target' => 'FILE',
+            'options' => array(
+                'filename' => 'gpm.log'
+            )
+        );
+
+        $this->modx->log($level, $message, $target);
     }
 }

--- a/core/components/gpm/src/Logger/MODX.php
+++ b/core/components/gpm/src/Logger/MODX.php
@@ -41,7 +41,7 @@ final class MODX implements LoggerInterface
             $level = self::$levelMap[$level];
         }
 
-        $target = (!$this->getOption('enable_file_log')) ? '' : array(
+        $target = (!$this->modx->getOption('gpm.enable_file_log', array(), false)) ? '' : array(
             'target' => 'FILE',
             'options' => array(
                 'filename' => 'gpm.log'


### PR DESCRIPTION
This branch adds the option to log the GPM processes to a file called "gpm.log", which will show up in `core/cache/logs`. It is disabled by default.  