### PR TITLE
Add encrypt/decrypt vehicle

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -52,6 +52,26 @@
         "value": "0",
         "type": "combo-boolean",
         "area": "system"
+      },
+      {
+        "key": "encrypt_key",
+        "value": "",
+        "area": "encrypt"
+      },
+      {
+        "key": "support_mail",
+        "value": "",
+        "area": "encrypt"
+      },
+      {
+        "key": "support_name",
+        "value": "",
+        "area": "encrypt"
+      },
+      {
+        "key": "support_url",
+        "value": "",
+        "area": "encrypt"
       }
     ]
   },

--- a/cli/src/GPM/Commands/Package/Build.php
+++ b/cli/src/GPM/Commands/Package/Build.php
@@ -26,6 +26,12 @@ class Build extends GPMCommand
                 InputOption::VALUE_NONE,
                 'If passed package key will be used instead of package name'
             )
+            ->addOption(
+                'encryptKey',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'If passed the package will be optional encrypted with that key'
+            )
         ;
     }
 
@@ -52,6 +58,7 @@ class Build extends GPMCommand
 
         $options = array(
             'id' => $pkg->id,
+            'encryptKey' => $input->getOption('encryptKey')
         );
 
         /** @var \modProcessorResponse $response */

--- a/core/components/gitpackagemanagement/docs/changelog.txt
+++ b/core/components/gitpackagemanagement/docs/changelog.txt
@@ -5,6 +5,7 @@ Changelog for GitPackageManagement.
 - Allow Widget Elements
 - Fix setting description for TVs
 - Fix setting output properties for TVs
+- Add encrypt/decrypt vehicle
 
 GitPackageManagement 0.11.0 alpha
 ==============

--- a/core/components/gitpackagemanagement/elements/transport/encryptvehicle.class.php
+++ b/core/components/gitpackagemanagement/elements/transport/encryptvehicle.class.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Encrypt Vehicle
+ *
+ * @package gitpackagemanagement
+ * @subpackage classfile
+ */
+
+use Psr\Http\Message\ResponseInterface;
+
+class_alias('encryptVehicle', 'xPDO\Transport\encryptVehicle');
+
+class encryptVehicle extends xPDOObjectVehicle
+{
+    public $class = 'encryptVehicle';
+    public const version = '3.0.0';
+    public const cipher = 'AES-256-CBC';
+
+    /**
+     * Put an encrypted xPDOObject representation into the vehicle
+     *
+     * @param xPDOTransport $transport
+     * @param mixed $object
+     * @param array $attributes
+     */
+    public function put(&$transport, &$object, $attributes = array())
+    {
+        parent::put($transport, $object, $attributes);
+
+        $this->payload['support_name'] = $transport->xpdo->getOption('gitpackagemanagement.support_name', null, $transport->xpdo->getOption('site_name'), true);
+        $this->payload['support_mail'] = $transport->xpdo->getOption('gitpackagemanagement.support_mail', null, $transport->xpdo->getOption('email_sender'), true);
+        $this->payload['support_url'] = $transport->xpdo->getOption('gitpackagemanagement.support_url', null, $transport->xpdo->getOption('hostname'), true);
+
+        $encryptKey = $transport->xpdo->getOption('gitpackagemanagement.encrypt_key');
+        if ($encryptKey) {
+            $this->payload['object_encrypted'] = $this->encrypt($this->payload['object'], $encryptKey);
+            unset($this->payload['object']);
+
+            if (isset($this->payload['related_objects'])) {
+                $this->payload['related_objects_encrypted'] = $this->encrypt($this->payload['related_objects'], $encryptKey);
+                unset($this->payload['related_objects']);
+            }
+
+            $transport->xpdo->log(xPDO::LOG_LEVEL_INFO, 'Package encrypted!');
+        } else {
+            $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Encrypt key not set. Package not encrypted!');
+        }
+    }
+
+    /**
+     * Install the decrypted xPDOObjects represented by vehicle into the transport host.
+     *
+     * @param xPDOTransport $transport
+     * @param array $options
+     *
+     * @return bool
+     */
+    public function install(&$transport, $options)
+    {
+        if (!$this->decryptPayloads($transport)) {
+            return false;
+        } else {
+            $transport->xpdo->log(xPDO::LOG_LEVEL_INFO, 'Package decrypted!');
+        }
+
+        return parent::install($transport, $options);
+    }
+
+    /**
+     * Uninstalls the decrypted xPDOObjects represented by vehicle from the transport host.
+     *
+     * @param xPDOTransport $transport
+     * @param array $options
+     * @return boolean
+     */
+    public function uninstall(&$transport, $options)
+    {
+        if (!$this->decryptPayloads($transport, 'uninstall')) {
+            return false;
+        } else {
+            $transport->xpdo->log(xPDO::LOG_LEVEL_INFO, 'Package decrypted!');
+        }
+
+        return parent::uninstall($transport, $options);
+    }
+
+    /**
+     * Encrypt the data
+     *
+     * @param array $data
+     * @param string $key
+     *
+     * @return string
+     */
+    protected function encrypt($data, $key)
+    {
+        $ivLen = openssl_cipher_iv_length(self::cipher);
+        $iv = openssl_random_pseudo_bytes($ivLen);
+        $cipher_raw = openssl_encrypt(serialize($data), self::cipher, $key, OPENSSL_RAW_DATA, $iv);
+
+        return base64_encode($iv . $cipher_raw);
+    }
+
+    /**
+     * Decrypt the data
+     *
+     * @param string $string
+     * @param string $key
+     * @param string $error Passed by reference, an error message from the decoding (if any)
+     * @return string
+     */
+    protected function decrypt($string, $key, &$error = '')
+    {
+        $ivLen = openssl_cipher_iv_length(self::cipher);
+        $encoded = base64_decode($string);
+        if (ini_get('mbstring.func_overload')) {
+            $strLen = mb_strlen($encoded, '8bit');
+            $iv = mb_substr($encoded, 0, $ivLen, '8bit');
+            $cipher_raw = mb_substr($encoded, $ivLen, $strLen, '8bit');
+        } else {
+            $iv = substr($encoded, 0, $ivLen);
+            $cipher_raw = substr($encoded, $ivLen);
+        }
+        $decrypted = openssl_decrypt($cipher_raw, self::cipher, $key, OPENSSL_RAW_DATA, $iv);
+        if ($decrypted === false) {
+            $error = 'Decryption failed: ';
+            while ($msg = openssl_error_string()) {
+                $error .= '- ' . $msg;
+            }
+            return false;
+        }
+        return unserialize($decrypted);
+    }
+
+    /**
+     * Decrypt the encrypted payload if the api_key and the username are allowed to install the package
+     *
+     * @param xPDOTransport $transport
+     * @param string $action
+     * @return bool
+     */
+    protected function decryptPayloads(&$transport, $action = 'install')
+    {
+        $error = '';
+        if (isset($this->payload['object_encrypted']) || isset($this->payload['related_objects_encrypted'])) {
+            if (!$key = $this->getDecryptKey($transport, $action)) {
+                $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not retrieve the decryption key.');
+                return false;
+            }
+            if (isset($this->payload['object_encrypted'])) {
+                $decrypted = $this->decrypt($this->payload['object_encrypted'], $key, $error);
+                if ($decrypted === false) {
+                    $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Failed to decrypt object with key ' . $key . ': ' . $error);
+                    $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Please try to install the package again and contact ' . $this->payload['support_mail'] . ', if the problem persists.');
+                    return false;
+                }
+                $this->payload['object'] = $decrypted;
+                unset($this->payload['object_encrypted']);
+            }
+            if (isset($this->payload['related_objects_encrypted'])) {
+                $decrypted = $this->decrypt($this->payload['related_objects_encrypted'], $key, $error);
+                if ($decrypted === false) {
+                    $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Failed to decrypt related objects with key ' . $key . ': ' . $error);
+                    $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Please try to install the package again and contact ' . $this->payload['support_mail'] . ', if the problem persists.');
+                    return false;
+                }
+                $this->payload['related_objects'] = $decrypted;
+                unset($this->payload['related_objects_encrypted']);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the decrypt key from the package provider
+     *
+     * @param xPDOTransport $transport
+     * @param string $action
+     *
+     * @return bool|string
+     */
+    protected function getDecryptKey(&$transport, $action)
+    {
+        $endpoint = 'package/decode/' . $action;
+
+        /** @var modTransportPackage|\MODX\Revolution\Transport\modTransportPackage $package */
+        $package = $transport->xpdo->getObject('transport.modTransportPackage', array(
+            'signature' => $transport->signature,
+        ));
+        if ($package) {
+            /** @var modTransportProvider|\MODX\Revolution\Transport\modTransportProvider $provider */
+            if ($provider = $package->getOne('Provider')) {
+                $provider->xpdo->setOption('contentType', 'default');
+                $params = array(
+                    'package' => $package->package_name,
+                    'version' => $transport->version,
+                    'signature' => $package->signature,
+                    'username' => $provider->username,
+                    'api_key' => $provider->api_key,
+                    'vehicle_version' => self::version,
+                );
+
+                $response = $provider->request($endpoint, 'POST', $params);
+                // On MODX 2.x and up to 3.0.0-alpha2, providers use modRestClient
+                if ($response instanceof modRestResponse) {
+                    if ($response->isError()) {
+                        $msg = $response->getError();
+                        $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, (string)$msg);
+                    } else {
+                        $data = $response->toXml();
+                        if (!empty($data->key)) {
+                            return base64_decode((string)$data->key);
+                        }
+
+                        if (!empty($data->message)) {
+                            $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, (string)$data->message);
+                        }
+                    }
+                } // MODX 3.0.0-alpha3 and up, providers return a PSR response
+                elseif ($response instanceof ResponseInterface) {
+                    $raw = $response->getBody()->getContents();
+                    $disableEntities = libxml_disable_entity_loader();
+                    $internalErrors = libxml_use_internal_errors(true);
+                    $data = simplexml_load_string($raw);
+                    libxml_disable_entity_loader($disableEntities);
+                    libxml_use_internal_errors($internalErrors);
+
+                    if (!empty($data->key)) {
+                        return base64_decode((string)$data->key);
+                    }
+
+                    if (!empty($data->message)) {
+                        $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, (string)$data->message);
+                    }
+                } else {
+                    $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not find the provider for this package. Please make sure this package was installed with the ' . $this->payload['support_name'] . ' package provider and contact ' . $this->payload['support_mail'] . ', if you need assistance.');
+                }
+            }
+        } else {
+            $transport->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Could not find the package object for ' . $transport->signature . '.');
+        }
+
+        return false;
+    }
+}

--- a/core/components/gitpackagemanagement/lexicon/en/default.inc.php
+++ b/core/components/gitpackagemanagement/lexicon/en/default.inc.php
@@ -35,6 +35,7 @@ $_lang['gitpackagemanagement.build_package'] = 'Build package';
 $_lang['gitpackagemanagement.check_lexicon'] = 'Check Lexicon';
 
 //Options
+$_lang['area_encrypt'] = 'Encrypt';
 $_lang['setting_gitpackagemanagement.build_path'] = 'Build path';
 $_lang['setting_gitpackagemanagement.build_path_desc'] = 'Folder, relatives to the package, to store build transport packages. Defaults to "/_packages/"';
 $_lang['setting_gitpackagemanagement.packages_dir'] = 'Packages directory';
@@ -49,6 +50,14 @@ $_lang['setting_gitpackagemanagement.disable_create_elements'] = 'Disable creati
 $_lang['setting_gitpackagemanagement.disable_create_elements_desc'] = 'By activating this setting, GPM lets the MODX installation alone. This is useful, when you want GPM to just create a package.';
 $_lang['setting_gitpackagemanagement.disable_update_elements'] = 'Disable updating anything in the MODX db';
 $_lang['setting_gitpackagemanagement.disable_update_elements_desc'] = 'By activating this setting, GPM lets the MODX installation alone. This is useful, when you want GPM to just create a package.';
+$_lang['setting_gitpackagemanagement.encrypt_key'] = 'Enrcypt Key';
+$_lang['setting_gitpackagemanagement.encrypt_key_desc'] = 'The package will be encrypted with this key, when encrypt is enabled in the build options.';
+$_lang['setting_gitpackagemanagement.support_mail'] = 'Support Email';
+$_lang['setting_gitpackagemanagement.support_mail_desc'] = 'The support email is shown when the package can\'t be decrypted.';
+$_lang['setting_gitpackagemanagement.support_name'] = 'Support Name';
+$_lang['setting_gitpackagemanagement.support_name_desc'] = 'The support name is shown when the package can\'t be decrypted.';
+$_lang['setting_gitpackagemanagement.support_url'] = 'Support URL';
+$_lang['setting_gitpackagemanagement.support_url_desc'] = 'The support url is shown when the package can\'t be decrypted.';
 
 //Errors
 $_lang['gitpackagemanagement.package_err_ns_folder_name'] = 'You have to enter folder name.';
@@ -64,4 +73,3 @@ $_lang['gitpackagemanagement.package_err_ccln'] = 'You can not update your packa
 $_lang['gitpackagemanagement.package_err_bc_nw'] = 'Build config is not writable. Please make [[+package]]/_build/build.config.php writable to continue.';
 $_lang['gitpackagemanagement.package_err_cc_nw'] = 'Core config is not writable. Please make [[+package]]/config.core.php writable to continue.';
 $_lang['gitpackagemanagement.package_err_dependencies'] = 'Dependencies check failed!';
-

--- a/core/components/gitpackagemanagement/model/gitpackagemanagement/builder/gitpackagevehicle.class.php
+++ b/core/components/gitpackagemanagement/model/gitpackagemanagement/builder/gitpackagevehicle.class.php
@@ -130,4 +130,23 @@ class GitPackageVehicle {
 
         return $this->addPHPResolver($resolver);
     }
+
+    public function addEncryptResolver($packagePath, $config) {
+        if (!is_dir($packagePath)) {
+            mkdir($packagePath);
+        }
+
+        $resolver = $packagePath . '/gpm.resolve.encrypt.php';
+        if (file_exists($resolver)) {
+            unlink($resolver);
+        }
+
+        $this->smarty->assign('lowercasename', $config->getLowCaseName());
+
+        $resolverContent = $this->smarty->fetch('encrypt_resolver.tpl');
+
+        file_put_contents($resolver, $resolverContent);
+
+        return $this->addPHPResolver($resolver);
+    }
 }

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -553,7 +553,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
             $vehicle = $this->builder->createVehicle($fileObject, array(
                 'vehicle_class' => 'xPDOScriptVehicle',
                 'object' => array(
-                    'source' => $resolversDir . $this->modx->getOption('encrypted_resolver', $buildOptions, 'resolve.encrypted.php')
+                    'source' => realpath($resolversDir . $this->modx->getOption('encrypted_resolver', $buildOptions, '../gpm_resolvers/gpm.resolve.encrypt.php'))
                 )
             ));
 
@@ -574,7 +574,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
             $vehicle = $this->builder->createVehicle($fileObject, array(
                 'vehicle_class' => 'xPDOScriptVehicle',
                 'object' => array(
-                    'source' => $resolversDir . $this->modx->getOption('encrypted_resolver', $buildOptions, 'resolve.encrypted.php'),
+                    'source' => realpath($resolversDir . $this->modx->getOption('encrypted_resolver', $buildOptions, '../gpm_resolvers/gpm.resolve.encrypt.php'))
                 )
             ));
         }

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -285,6 +285,19 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
             $categoryVehicle->attributes[xPDOTransport::ABORT_INSTALL_ON_VEHICLE_FAIL] = true;
         }
 
+        if ($this->modx->getOption('encrypt', $buildOptions, false)) {
+            $vehicleClass = $this->modx->getOption('gitpackagemanagement.encrypt_vehicle_class', null, 'encryptVehicle');
+            $vehiclePath = $this->modx->getOption('gitpackagemanagement.encrypt_vehicle_path', null, $this->modx->getOption('gitpackagemanagement.core_path') . 'elements/');
+            if ($this->getProperty('encryptKey')) {
+                $this->modx->setOption('gitpackagemanagement.encrypt_key', $this->getProperty('encryptKey'));
+            }
+
+            $categoryVehicle = $category->getVehicle();
+            $categoryVehicle->attributes['vehicle_class'] = $vehicleClass;
+            $categoryVehicle->attributes['vehicle_package_path'] = $vehiclePath;
+            $categoryVehicle->attributes[xPDOTransport::ABORT_INSTALL_ON_VEHICLE_FAIL] = true;
+        }
+
         return $category;
     }
 
@@ -487,8 +500,7 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
         return $plugins;
     }
 
-    protected function emptyFolder($path, $filemask = '*')
-    {
+    protected function emptyFolder($path, $filemask = '*') {
         $inverse = false;
         if (strpos($filemask, '!') === 0) {
             $filemask = substr($filemask, 1);
@@ -510,9 +522,59 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
         return;
     }
 
-    protected function prependVehicles() {}
+    protected function prependVehicles() {
+        $buildOptions = $this->config->getBuild()->getBuildOptions();
 
-    protected function appendVehicles() {}
+        if ($this->modx->getOption('encrypt', $buildOptions, false)) {
+            $resolversDir = $this->config->getBuild()->getResolver()->getResolversDir();
+            $resolversDir = trim($resolversDir, '/');
+            $resolversDir = $this->packagePath . '_build/' . $resolversDir . '/';
+
+            $this->modx->loadClass('xPDOFileVehicle', MODX_CORE_PATH . 'xpdo/transport/', true, true);
+            $fileObject = new xPDOFileVehicle();
+            $vehiclePath = $this->modx->getOption('gitpackagemanagement.encrypt_vehicle_path', null, $this->modx->getOption('gitpackagemanagement.core_path') . 'elements/transport/encryptvehicle.class.php');
+            $vehicle = $this->builder->createVehicle($fileObject, array(
+                'vehicle_class' => 'xPDOFileVehicle',
+                'object' => array(
+                    'source' => $vehiclePath,
+                    'target' => 'return MODX_CORE_PATH . "components/' . $this->config->getLowCaseName() . '_vehicle/";',
+                    'name' => 'encryptvehicle.class.php'
+                )
+            ));
+
+            $this->builder->putVehicle($vehicle);
+
+            $this->modx->loadClass('xPDOScriptVehicle', MODX_CORE_PATH . 'xpdo/transport/', true, true);
+            $fileObject = new xPDOScriptVehicle();
+            $vehicle = $this->builder->createVehicle($fileObject, array(
+                'vehicle_class' => 'xPDOScriptVehicle',
+                'object' => array(
+                    'source' => $resolversDir . $this->modx->getOption('encrypted_resolver', $buildOptions, 'resolve.encrypted.php')
+                )
+            ));
+
+            $this->builder->putVehicle($vehicle);
+        }
+    }
+
+    protected function appendVehicles() {
+        $buildOptions = $this->config->getBuild()->getBuildOptions();
+
+        if ($this->modx->getOption('encrypt', $buildOptions, false)) {
+            $resolversDir = $this->config->getBuild()->getResolver()->getResolversDir();
+            $resolversDir = trim($resolversDir, '/');
+            $resolversDir = $this->packagePath . '_build/' . $resolversDir . '/';
+
+            $this->modx->loadClass('xPDOScriptVehicle', MODX_CORE_PATH . 'xpdo/transport/', true, true);
+            $fileObject = new xPDOScriptVehicle();
+            $vehicle = $this->builder->createVehicle($fileObject, array(
+                'vehicle_class' => 'xPDOScriptVehicle',
+                'object' => array(
+                    'source' => $resolversDir . $this->modx->getOption('encrypted_resolver', $buildOptions, 'resolve.encrypted.php'),
+                )
+            ));
+        }
+    }
 
     private function addMenus() {
         /** @var GitPackageConfigMenu[] $menus */

--- a/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
+++ b/core/components/gitpackagemanagement/processors/mgr/gitpackage/buildpackage.class.php
@@ -182,6 +182,10 @@ class GitPackageManagementBuildPackageProcessor extends modObjectProcessor {
             $vehicle->addPHPResolver($resolversDir . ltrim($script, '/'));
         }
 
+        if ($this->modx->getOption('encrypt', $this->config->getBuild()->getBuildOptions(), false)) {
+            $vehicle->addEncryptResolver($this->packagePath . '_build/gpm_resolvers', $this->config);
+        }
+
         $this->builder->putVehicle($vehicle);
         $this->addMenus();
 

--- a/core/components/gitpackagemanagement/templates/gitpackagebuild/encrypt_resolver.tpl
+++ b/core/components/gitpackagemanagement/templates/gitpackagebuild/encrypt_resolver.tpl
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Resolve loading the encrypt class
+ *
+ * THIS RESOLVER IS AUTOMATICALLY GENERATED, NO CHANGES WILL APPLY
+ *
+ * @package {{$lowercasename}}
+ * @subpackage build
+ *
+ * @var xPDOTransport $transport
+ */
+
+$transport->xpdo->loadClass('transport.xPDOObjectVehicle', XPDO_CORE_PATH, true, true);
+$transport->xpdo->loadClass('encryptVehicle', MODX_CORE_PATH . 'components/{{$lowercasename}}_vehicle/', true, true);
+
+return true;

--- a/core/components/gitpackagemanagement/templates/gitpackagebuild/encrypt_resolver.tpl
+++ b/core/components/gitpackagemanagement/templates/gitpackagebuild/encrypt_resolver.tpl
@@ -10,7 +10,9 @@
  * @var xPDOTransport $transport
  */
 
-$transport->xpdo->loadClass('transport.xPDOObjectVehicle', XPDO_CORE_PATH, true, true);
-$transport->xpdo->loadClass('encryptVehicle', MODX_CORE_PATH . 'components/{{$lowercasename}}_vehicle/', true, true);
+if ($transport->xpdo) {
+    $transport->xpdo->loadClass('transport.xPDOObjectVehicle', XPDO_CORE_PATH, true, true);
+    $transport->xpdo->loadClass('encryptVehicle', MODX_CORE_PATH . 'components/{{$lowercasename}}_vehicle/', true, true);
+}
 
 return true;


### PR DESCRIPTION
It allows to encrypt the package with the build option `encrypt`. The package will be encrypted with the key in `gitpackagemanagement.encrypt_key` or with the CLI `encryptKey` property. During the installation the package provider has to send the key with the endpoint `package/decode/install` or `package/decode/uninstall`

The vehicle adds the `gitpackagemanagement.support_mail`, `gitpackagemanagement.support_name` and the `gitpackagemanagement.support_url` system setting values into the payload to provide some better error messages to the customer, when the package can't be decrypted.

To use the encrypt option, you have to add a `resolve.encrypted.php` resolver on base of the `encrypt_resolver.tpl` template. Maybe this can be automated somehow.