### PR TITLE
FlySystem writing empty files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ core/components/gpm/vendor
 cache/*
 _packages/
 config.core.php
+.idea

--- a/core/components/gpm/src/Config/Parts/Element/Element.php
+++ b/core/components/gpm/src/Config/Parts/Element/Element.php
@@ -152,10 +152,10 @@ abstract class Element extends Part
                 $obj->set('static', 0);
                 $obj->set('static_file', '');
             } else {
-                $obj->set('content', '');
+                $obj->set('content', file_get_contents($this->absoluteFilePath));
                 $obj->set('static', 1);
                 $obj->set('source', 0);
-                $obj->set('static_file', $this->absoluteFilePath);
+                $obj->set('static_file', '[[++' . $this->config->general->lowCaseName . '.core_path]]' . $this->filePath);
             }
         } else {
             $obj->set('content', file_get_contents($this->absoluteFilePath));

--- a/core/components/gpm/src/Config/Parts/Element/Element.php
+++ b/core/components/gpm/src/Config/Parts/Element/Element.php
@@ -155,7 +155,7 @@ abstract class Element extends Part
                 $obj->set('content', '');
                 $obj->set('static', 1);
                 $obj->set('source', 0);
-                $obj->set('static_file', '[[++' . $this->config->general->lowCaseName . '.core_path]]' . $this->filePath);
+                $obj->set('static_file', $this->absoluteFilePath);
             }
         } else {
             $obj->set('content', file_get_contents($this->absoluteFilePath));


### PR DESCRIPTION
Changing from placeholder paths to absolute paths when creating / updating elements prevents FlySystem from writing out an empty file. I'm not sure if there is a more graceful way to implement this change, but this seems to work. 