### PR TITLE
Add field "options" to Property

### DIFF
--- a/core/components/gpm/src/Config/Parts/Property.php
+++ b/core/components/gpm/src/Config/Parts/Property.php
@@ -40,9 +40,14 @@ class Property extends Part
     /** @var string */
     protected $area = '';
 
+    protected $options = [];
+
     protected $rules = [
         'name' => [Rules::isString, Rules::notEmpty],
         'type' => [Rules::isString],
+        'options' => [
+            ['rule' => Rules::isArray, 'params' => ['itemRules' => [Rules::isArray]]]
+        ],
     ];
 
     protected function generator(): void
@@ -65,6 +70,7 @@ class Property extends Part
             'value' => $this->value,
             'lexicon' => $this->lexicon,
             'area' => $this->area,
+            'options' => $this->options,
         ];
     }
 }


### PR DESCRIPTION
If you have a (snippet-) property of type "list" with options, these options get ignored by GPM at the moment.

Example config (gpm.yaml):
```
snippets:
  - name: mySnippet
    properties:
      - name: myProp
        type: list
        options:
          - text: text1
            value: value1
          - text: text2
            value: value2
        value: value2
```
This PR should fix this.