### PR TITLE
Fix typo for modMenu "menuindex" field

### DIFF
--- a/core/components/gpm/src/Config/Parts/Menu.php
+++ b/core/components/gpm/src/Config/Parts/Menu.php
@@ -40,7 +40,7 @@ class Menu extends Part
     protected $icon = '';
 
     /** @var int */
-    protected $menuIndex = '';
+    protected $menuIndex = 0;
 
     /** @var string */
     protected $params = '';

--- a/core/components/gpm/src/Config/Parts/Menu.php
+++ b/core/components/gpm/src/Config/Parts/Menu.php
@@ -52,7 +52,8 @@ class Menu extends Part
     protected $permission = '';
 
     protected $rules = [
-        'text' => [Rules::isString, Rules::notEmpty]
+        'text' => [Rules::isString, Rules::notEmpty],
+        'menuIndex' => [Rules::isInt]
     ];
 
     protected function generator(): void
@@ -79,7 +80,7 @@ class Menu extends Part
         $obj->set('parent', $this->parent);
         $obj->set('description', $this->description);
         $obj->set('icon', $this->icon);
-        $obj->set('menundex', $this->menuIndex);
+        $obj->set('menuindex', $this->menuIndex);
         $obj->set('params', $this->params);
         $obj->set('handler', $this->handler);
         $obj->set('permission', $this->permission);


### PR DESCRIPTION
Fixed the typo and changed the rule to check for an integer.