### PR TITLE
Fix fatal error

### DIFF
--- a/core/components/gpm/src/Logger/MODX.php
+++ b/core/components/gpm/src/Logger/MODX.php
@@ -32,7 +32,7 @@ final class MODX implements LoggerInterface
      * @param  string  $message
      * @param  array  $context
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $message = str_replace(PHP_EOL, '<br>', $message);
         $message = str_replace('    ', '&nbsp;&nbsp;&nbsp;&nbsp;', $message);


### PR DESCRIPTION
PHP Fatal error:  Declaration of GPM\Logger\MODX::log($level, $message, array $context = []) must be compatible with Psr\Log\LoggerTrait::log($level, Stringable|string $message, array $context = []): void in /.../core/components/gpm/src/Logger/MODX.php on line 35

This occurs in PHP 8.2.x