### PR TITLE
Set TV sortOrder type to integer

### DIFF
--- a/core/components/gpm/src/Config/Parts/Element/TemplateVar.php
+++ b/core/components/gpm/src/Config/Parts/Element/TemplateVar.php
@@ -46,8 +46,8 @@ class TemplateVar extends Element
     /** @var array */
     protected $templates = [];
 
-    /** @var string */
-    protected $sortOrder = '0';
+    /** @var int */
+    protected $sortOrder = 0;
 
     protected $rules = [
         'name' => [Rules::isString, Rules::notEmpty],


### PR DESCRIPTION
The JSON schema demands that this field is an integer (which is correct), but the install command was throwing the error: sortOrder has to be string, integer given.