### PR TITLE
Don't expect static file for TVs

### DIFF
--- a/core/components/gpm/src/Config/Parts/Element/TemplateVar.php
+++ b/core/components/gpm/src/Config/Parts/Element/TemplateVar.php
@@ -56,7 +56,7 @@ class TemplateVar extends Element
         'inputOptionValues' => [Rules::isString],
         'outputType' => [Rules::isString],
         'category' => [Rules::isArray, Rules::categoryExists],
-        'file' => [Rules::isString, Rules::notEmpty, Rules::elementFileExists],
+        'file' => [Rules::isString],
         'properties' => [
             ['rule' => Rules::isArray, 'params' => ['itemRules' => [Rules::configPart]]]
         ],


### PR DESCRIPTION
This was generating errors for me.

[error] TemplateVar: fb_hooks - file "elements/templateVars/fb_hooks." doesn't exist

 It seems that TVs can be static also, but I never used that feature so I don't know what it expects..