### PR TITLE
Check old 2.x category paths

### DIFF
--- a/core/components/gpm/src/Config/Parts/Element/Element.php
+++ b/core/components/gpm/src/Config/Parts/Element/Element.php
@@ -86,6 +86,7 @@ abstract class Element extends Part
 
         $pathsToCheck = [];
         $pathsToCheck[] = $baseSnippetsPath . $this->file;
+        $pathsToCheck[] = $baseSnippetsPath . strtolower($this->name) . '.' . $this->_type . '.' . $this->extension;;
 
         $this->absoluteFilePath = $baseSnippetsPath . $this->file;
         $this->filePath = str_replace($this->config->paths->core, '', $this->absoluteFilePath);

--- a/core/components/gpm/src/Config/Parts/Element/Element.php
+++ b/core/components/gpm/src/Config/Parts/Element/Element.php
@@ -93,6 +93,7 @@ abstract class Element extends Part
         if (!empty($this->category)) {
             $category = implode(DIRECTORY_SEPARATOR, $this->category) . DIRECTORY_SEPARATOR;
             $pathsToCheck[] = $baseSnippetsPath . $category . $this->file;
+            $pathsToCheck[] = $baseSnippetsPath . $category . strtolower($this->name) . '.' . $this->_type . '.' . $this->extension;
             $pathsToCheck[] = $baseSnippetsPath . str_replace(' ', '-', strtolower($category)) . $this->file;
         }
 


### PR DESCRIPTION
For backwards compatibility, also accept paths using the old 2.x format (category/elementname.chunk.tpl).

This avoids having to add a file path to each object when migrating packages from GPM 2.x to 3.x.