### PR TITLE
Don't include vendor folder in transport package

### DIFF
--- a/core/components/gpm/src/Config/Parts/Build.php
+++ b/core/components/gpm/src/Config/Parts/Build.php
@@ -14,6 +14,7 @@ use Psr\Log\LoggerInterface;
  * @property-read array $scriptsBefore
  * @property-read array $scriptsAfter
  * @property-read array $requires
+ * @property-read bool $composer
  * @property-read string $setupOptions
  * @property-read string $installValidator
  * @property-read string $unInstallValidator
@@ -44,6 +45,9 @@ class Build extends Part
     /** @var string[] */
     protected $requires = [];
 
+    /** @var bool */
+    protected $composer = false;
+
     /** @var string */
     protected $setupOptions = '';
 
@@ -64,6 +68,7 @@ class Build extends Part
             ['rule' => Rules::isArray, 'params' => ['itemRules' => [Rules::isString, Rules::scriptExists]]]
         ],
         'requires' => [Rules::isArray, Rules::packageDependencies],
+        'composer' => [Rules::isBool],
         'setupOptions' => [Rules::isString, Rules::buildFileExists],
         'installValidator' => [Rules::isString, Rules::scriptExists],
         'unInstallValidator' => [Rules::isString, Rules::scriptExists],

--- a/core/components/gpm/src/Operations/Build.php
+++ b/core/components/gpm/src/Operations/Build.php
@@ -210,12 +210,24 @@ class Build extends Operation {
             ];
         }
 
+        // Don't include the vendor folder in the package (thanks @Jako for this part)
+        $vendorPath = $this->config->paths->core . 'vendor/';
+        $tempVendorPath = $this->config->paths->build . '/temp_vendor/';
+        if ($this->config->build->composer) {
+            rename($vendorPath, $tempVendorPath);
+        }
+
         $this->package->put($namespace, [
             xPDOTransport::UNIQUE_KEY    => 'name',
             xPDOTransport::PRESERVE_KEYS => true,
             xPDOTransport::UPDATE_OBJECT => true,
             'resolve' => $namespaceResolvers
         ]);
+
+        // Restore original vendor folder
+        if ($this->config->build->composer) {
+            rename($tempVendorPath, $vendorPath);
+        }
     }
 
     protected function packSystemSettings(): void


### PR DESCRIPTION
This revives the old 'composer' flag from @Jako . If set to true, the vendor folder will be moved temporarily and restored after the transport package is created.